### PR TITLE
always use the latest version of node-pixel

### DIFF
--- a/lib/firmwares.json
+++ b/lib/firmwares.json
@@ -24,7 +24,8 @@
       "repo": "url",
       "npm": {
           "package": "node-pixel",
-          "version": "^0.4.1"
+          "repo": "git+https://github.com/ajfisher/node-pixel",
+          "version": ""
       },
       "description": "Allows NeoPixels to be used via I2C and the node-pixel controller",
       "docs": "url",


### PR DESCRIPTION
Alternatively bump the version?
