### PR TITLE
chore: added standard version configuration

### DIFF
--- a/.versionrc
+++ b/.versionrc
@@ -1,0 +1,13 @@
+{
+    "types": [
+        {"type": "feat", "section": "Features"},
+        {"type": "fix", "section": "Bug Fixes"},
+        {"type": "test", "section": "Tests", "hidden": false},
+        {"type": "build", "section": "Build System", "hidden": false},
+        {"type": "ci", "section": "Build System", "hidden": false},
+        {"type": "chore", "section": "Chores", "hidden": false},
+        {"type": "docs", "section": "Documentation", "hidden": false},
+        {"type": "refactors", "section": "Refactoring", "hidden": false},
+        {"type": "sec", "section": "Security fixes", "hidden": false}
+    ]
+}


### PR DESCRIPTION
No configuration for standard-version meant it wasn't pulling all the right information out into the changelog